### PR TITLE
Add tests for reporters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,8 @@ nitpick_ignore = [
     ("py:class", "jmespath.functions.Functions"),
     ("py:class", "jmespath.parser.ParsedResult"),
     ("py:class", "project_config.types.Results"),
+    ("py:class", "pytest.MonkeyPatch"),
+    ("py:class", "_pytest.monkeypatch.MonkeyPatch"),
 ]
 nitpick_ignore_regex = [
     ("py:class", r"^t.[A-Z]\w+$"),

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -118,6 +118,6 @@ Testing plugins
 
 **project-config** comes with a built-in `pytest fixture`_ to
 easily test plugin actions. See
-:py:mod:`project_config.tests.pytest_plugin`.
+:py:mod:`project_config.tests.pytest_plugin.plugin`.
 
 .. _pytest fixture: https://docs.pytest.org/en/latest/explanation/fixtures.html

--- a/docs/dev/reporters.rst
+++ b/docs/dev/reporters.rst
@@ -69,3 +69,12 @@ parts of the output.
 
 See the built-in reporters at :ref:`reporters submodules <dev/reference/project_config.reporters:Submodules>`
 and the :py:mod:`project_config.reporters.base` module for more information.
+
+Testing reporters
+=================
+
+**project-config** comes with built-in `pytest fixtures`_ to
+easily test reports generated from reporters. See
+:py:mod:`project_config.tests.pytest_plugin.plugin`.
+
+.. _pytest fixtures: https://docs.pytest.org/en/latest/explanation/fixtures.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ addopts = "-s --cov=src --cov-report=html"
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "if __name__ == [\"']__main__[\"']:"]
+omit = ["src/project_config/tests/*"]
 
 [tool.mypy]
 python_version = "3.7"

--- a/src/project_config/project.py
+++ b/src/project_config/project.py
@@ -265,7 +265,7 @@ class Project:
         if args.data == "cache":
             from project_config.cache import _directory
 
-            report = f"{_directory()}\n"
+            report = _directory()
         else:
             data = t.cast(t.Any, self.config.dict_)
             if args.data == "config":

--- a/src/project_config/project.py
+++ b/src/project_config/project.py
@@ -278,7 +278,7 @@ class Project:
 
             report = self.reporter.generate_data_report(args.data, data)
 
-        sys.stdout.write(report)
+        sys.stdout.write(f"{report}\n")
 
     def clean(self, args: argparse.Namespace) -> None:
         """Cleaning command."""

--- a/src/project_config/reporters/base.py
+++ b/src/project_config/reporters/base.py
@@ -80,16 +80,17 @@ class BaseReporter(abc.ABC):
             error (dict): Error to report.
         """
         if "file" in error:
-            error["file"] = os.path.relpath(error["file"], self.rootdir) + (
-                "/" if error["file"].endswith("/") else ""
+            file = error.pop("file")
+            file = os.path.relpath(file, self.rootdir) + (
+                "/" if file.endswith("/") else ""
             )
         else:
-            error["file"] = "[CONFIGURATION]"
+            file = "[CONFIGURATION]"
 
-        if error["file"] not in self.errors:
-            self.errors[error["file"]] = []
+        if file not in self.errors:
+            self.errors[file] = []
 
-        self.errors[error["file"]].append(error)
+        self.errors[file].append(error)
 
 
 class BaseFormattedReporter(BaseReporter, abc.ABC):

--- a/src/project_config/reporters/base.py
+++ b/src/project_config/reporters/base.py
@@ -80,16 +80,16 @@ class BaseReporter(abc.ABC):
             error (dict): Error to report.
         """
         if "file" in error:
-            file = os.path.relpath(error["file"], self.rootdir) + (
+            error["file"] = os.path.relpath(error["file"], self.rootdir) + (
                 "/" if error["file"].endswith("/") else ""
             )
         else:
-            file = "[CONFIGURATION]"
+            error["file"] = "[CONFIGURATION]"
 
-        if file not in self.errors:
-            self.errors[file] = []
+        if error["file"] not in self.errors:
+            self.errors[error["file"]] = []
 
-        self.errors[file].append(error)
+        self.errors[error["file"]].append(error)
 
 
 class BaseFormattedReporter(BaseReporter, abc.ABC):

--- a/src/project_config/reporters/base.py
+++ b/src/project_config/reporters/base.py
@@ -12,6 +12,7 @@ from project_config.types import ErrorDict
 
 
 FilesErrors: TypeAlias = t.Dict[str, t.List[ErrorDict]]
+FormatterDefinitionType: TypeAlias = t.Callable[[str], str]
 
 
 class BaseReporter(abc.ABC):

--- a/src/project_config/reporters/default.py
+++ b/src/project_config/reporters/default.py
@@ -10,7 +10,7 @@ from project_config.reporters.base import (
 )
 
 
-class DefaultBaseReporter(BaseFormattedReporter):
+class BaseDefaultReporter(BaseFormattedReporter):
     """Base reporter for default reporters."""
 
     def generate_errors_report(self) -> str:
@@ -110,7 +110,7 @@ class DefaultBaseReporter(BaseFormattedReporter):
         return report
 
 
-class DefaultReporter(BaseNoopFormattedReporter, DefaultBaseReporter):
+class DefaultReporter(BaseNoopFormattedReporter, BaseDefaultReporter):
     """Default black/white reporter."""
 
     def format_error_message(self, error_message: str) -> str:
@@ -118,7 +118,7 @@ class DefaultReporter(BaseNoopFormattedReporter, DefaultBaseReporter):
         return f"- {error_message}"
 
 
-class DefaultColorReporter(BaseColorReporter, DefaultBaseReporter):
+class DefaultColorReporter(BaseColorReporter, BaseDefaultReporter):
     """Default color reporter."""
 
     def format_error_message(self, error_message: str) -> str:

--- a/src/project_config/reporters/default.py
+++ b/src/project_config/reporters/default.py
@@ -107,7 +107,7 @@ class BaseDefaultReporter(BaseFormattedReporter):
                         f"\n{self.format_config_value(indented_value)}\n"
                     )
 
-        return report
+        return report.rstrip("\n")
 
 
 class DefaultReporter(BaseNoopFormattedReporter, BaseDefaultReporter):

--- a/src/project_config/reporters/json.py
+++ b/src/project_config/reporters/json.py
@@ -40,15 +40,19 @@ class JsonColorReporter(BaseColorReporter):
         message_key = self.format_key('"message"')
         definition_key = self.format_key('"definition"')
 
-        # separators for pretty formatting
+        space = " "
         if not self.format:
+            # separators for pretty formatting
             newline0 = newline2 = newline4 = newline6 = ""
         else:
-            space = " " if self.format == "pretty" else "  "
+            mul = 1 if self.format == "pretty" else 2
             newline0 = "\n"
-            newline2 = "\n" + space * 2
-            newline4 = "\n" + space * 4
-            newline6 = "\n" + space * 6
+            newline2 = "\n" + space * 2 * mul
+            newline4 = "\n" + space * 4 * mul
+            newline6 = "\n" + space * 6 * mul
+
+        if not self.errors:
+            return "{}"
 
         report = f"{self.format_metachar('{')}{newline2}"
         for f, (file, errors) in enumerate(self.errors.items()):
@@ -67,16 +71,16 @@ class JsonColorReporter(BaseColorReporter):
                 report += (
                     f"{self.format_metachar('{')}{newline6}{message_key}:"
                     f" {error_message}"
-                    f'{self.format_metachar(", ")}{newline6}'
+                    f'{self.format_metachar(",")}{newline6 or space}'
                     f'{definition_key}{self.format_metachar(":")}'
                     f" {definition}"
                     f"{newline4}{self.format_metachar('}')}"
                 )
                 if e < len(errors) - 1:
-                    report += f'{self.format_metachar(", ")}{newline4}'
+                    report += f'{self.format_metachar(",")}{newline4 or space}'
             report += f"{newline2}{self.format_metachar(']')}"
             if f < len(self.errors) - 1:
-                report += f'{self.format_metachar(", ")}{newline2}'
+                report += f'{self.format_metachar(",")}{newline2 or space}'
 
         return f"{report}{newline0}{self.format_metachar('}')}"
 
@@ -108,20 +112,23 @@ class JsonColorReporter(BaseColorReporter):
                     f'{self.format_metachar(":")}'
                 )
                 if isinstance(value, list):
-                    report += f' {self.format_metachar("[")}{newline4}'
+                    report += f'{space}{self.format_metachar("[")}{newline4}'
                     for i, value_item in enumerate(value):
                         report += self.format_config_value(
                             json.dumps(value_item),
                         )
                         if i < len(value) - 1:
-                            report += f'{self.format_metachar(",")} {newline4}'
+                            report += (
+                                f'{self.format_metachar(",")}'
+                                f"{newline4 or space}"
+                            )
                         else:
                             report += f'{newline2}{self.format_metachar("]")}'
                 else:
                     report += f" {self.format_config_value(json.dumps(value))}"
 
                 if d < len(data) - 1:
-                    report += f'{self.format_metachar(",")} {newline2}'
+                    report += f'{self.format_metachar(",")}{newline2 or space}'
             report += f'{newline0}{self.format_metachar("}")}'
         else:
             plugins = data.pop("plugins", [])

--- a/src/project_config/reporters/table.py
+++ b/src/project_config/reporters/table.py
@@ -67,7 +67,7 @@ class TableReporter(BaseNoopFormattedReporter):
             self.format_file,
             self.format_error_message,
             self.format_definition,
-        )
+        ).rstrip("\n")
 
 
 class TableColorReporter(BaseColorReporter):
@@ -82,4 +82,4 @@ class TableColorReporter(BaseColorReporter):
             self.format_file,
             self.format_error_message,
             self.format_definition,
-        )
+        ).rstrip("\n")

--- a/src/project_config/reporters/table.py
+++ b/src/project_config/reporters/table.py
@@ -8,14 +8,15 @@ from project_config.reporters.base import (
     BaseColorReporter,
     BaseNoopFormattedReporter,
     FilesErrors,
+    FormatterDefinitionType,
 )
 
 
 def _common_generate_rows(
     errors: FilesErrors,
-    format_file: t.Callable[[str], str],
-    format_error_message: t.Callable[[str], str],
-    format_definition: t.Callable[[str], str],
+    format_file: FormatterDefinitionType,
+    format_error_message: FormatterDefinitionType,
+    format_definition: FormatterDefinitionType,
 ) -> t.List[t.List[str]]:
     rows = []
     for file, file_errors in errors.items():
@@ -33,10 +34,10 @@ def _common_generate_rows(
 def _common_generate_errors_report(
     errors: FilesErrors,
     fmt: str,
-    format_key: t.Callable[[str], str],
-    format_file: t.Callable[[str], str],
-    format_error_message: t.Callable[[str], str],
-    format_definition: t.Callable[[str], str],
+    format_key: FormatterDefinitionType,
+    format_file: FormatterDefinitionType,
+    format_error_message: FormatterDefinitionType,
+    format_definition: FormatterDefinitionType,
 ) -> str:
     return tabulate(
         _common_generate_rows(

--- a/src/project_config/reporters/toml.py
+++ b/src/project_config/reporters/toml.py
@@ -5,44 +5,78 @@ import typing as t
 
 import tomli_w
 
-from project_config.reporters.base import BaseColorReporter, BaseReporter
+from project_config.reporters.base import (
+    BaseColorReporter,
+    BaseNoopFormattedReporter,
+    FilesErrors,
+    FormatterDefinitionType,
+)
 
 
-def _toml_dump_flow_style(obj: t.Any, indent: int = 0) -> str:
-    result = ""
-    if obj is None:
-        result += (" " * indent) + '""'
-    elif isinstance(obj, str):
-        result += (" " * indent) + json.dumps(obj)
-    elif isinstance(obj, list):
-        # FIXME: error in arrays inside objects
-        result += (" " * indent) + "[\n"
-        for item in obj:
-            result += _toml_dump_flow_style(item, indent=indent + 2) + ",\n"
-        result += (" " * indent) + "],"
-    elif isinstance(obj, dict):
-        result += (" " * indent) + "{\n"
-        for key, value in obj.items():
-            result += (
-                _toml_dump_flow_style(key, indent=indent + 2)
-                + " = "
-                + _toml_dump_flow_style(value, indent=indent + 2)
-                + "\n"
+def _replace_nulls_by_repr_strings_in_dict(
+    data: t.Dict[str, t.Any],
+) -> t.Dict[str, t.Any]:
+    """Iterates through a dictionary and replaces nulls by empty strings."""
+    if isinstance(data, dict):
+        return {
+            key: _replace_nulls_by_repr_strings_in_dict(value)
+            for key, value in data.items()
+        }
+    elif isinstance(data, list):
+        return [_replace_nulls_by_repr_strings_in_dict(value) for value in data]
+    elif data is None:
+        return "!!null"
+    return data
+
+
+def _normalize_indentation_to_2_spaces(string: str) -> str:
+    """Normalizes indentation of the beginning of lines to 2 spaces."""
+    new_lines: t.List[str] = []
+
+    for line in string.splitlines():
+        # count number of spaces at the beginning of the line
+        spaces_at_start = len(line) - len(line.lstrip())
+        if spaces_at_start < 3:
+            new_lines.append(line)
+        else:
+            new_lines.append(f'{" " * int(spaces_at_start / 2)}{line.lstrip()}')
+
+    return "\n".join(new_lines)
+
+
+def _common_generate_errors_report(
+    files_errors: FilesErrors,
+    format_file: FormatterDefinitionType,
+    format_key: FormatterDefinitionType,
+    format_error_message: FormatterDefinitionType,
+    format_definition: FormatterDefinitionType,
+) -> str:
+    report = ""
+    for file, errors in files_errors.items():
+        report += f"[[{format_file(file)}]]\n"
+
+        for error in errors:
+            report += (
+                f"{format_key('message')} ="
+                f" {format_error_message(json.dumps(error['message']))}\n"
+                f"{format_key('definition')} ="
+                f" {format_definition(error['definition'])}\n\n"
             )
-        result += (" " * indent) + "}\n"
-    elif isinstance(obj, bool):
-        result += (" " * indent) + ("true" if obj else "false")
-    else:
-        result += (" " * indent) + str(obj)
-    return result.rstrip("\n").rstrip(",")
+    return report.rstrip("\n")
 
 
-class TomlReporter(BaseReporter):
+class TomlReporter(BaseNoopFormattedReporter):
     """Black/white reporter in TOML format."""
 
     def generate_errors_report(self) -> str:
         """Generate an errors report in black/white TOML format."""
-        return tomli_w.dumps(self.errors)  # type: ignore
+        return _common_generate_errors_report(
+            self.errors,
+            self.format_file,
+            self.format_key,
+            self.format_error_message,
+            self.format_definition,
+        )
 
     def generate_data_report(
         self,
@@ -50,7 +84,17 @@ class TomlReporter(BaseReporter):
         data: t.Dict[str, t.Any],
     ) -> str:
         """Generate a data report in black/white TOML format."""
-        return tomli_w.dumps(data)  # type: ignore
+        report = ""
+        if "plugins" in data:
+            if not data["plugins"]:
+                data.pop("plugins")
+            elif len(data["plugins"]) == 1:
+                plugin = data.pop("plugins")[0]
+                report += f"plugins = [{json.dumps(plugin)}]\n\n"
+        report += tomli_w.dumps(
+            _replace_nulls_by_repr_strings_in_dict(data),
+        )
+        return _normalize_indentation_to_2_spaces(report)
 
 
 class TomlColorReporter(BaseColorReporter):
@@ -58,35 +102,13 @@ class TomlColorReporter(BaseColorReporter):
 
     def generate_errors_report(self) -> str:
         """Generate an errors report in TOML format with colors."""
-        report = ""
-        for line in tomli_w.dumps(self.errors).splitlines():
-            if line.startswith("[["):
-                report += (
-                    f"{self.format_metachar('[[')}"
-                    f"{self.format_file(line[2:-2])}"
-                    f"{self.format_metachar(']]')}\n"
-                )
-            elif line.startswith("message = "):
-                error_message = self.format_error_message(
-                    line.split(" ", maxsplit=2)[2],
-                )
-                report += (
-                    f"{self.format_key('message')}"
-                    f" {self.format_metachar('=')}"
-                    f" {error_message}\n"
-                )
-            elif line.startswith("definition = "):
-                definition = self.format_definition(
-                    line.split(" ", maxsplit=2)[2],
-                )
-                report += (
-                    f"{self.format_key('definition')}"
-                    f" {self.format_metachar('=')}"
-                    f" {definition}\n"
-                )
-            else:
-                report += f"{line}\n"
-        return report.rstrip("\n")
+        return _common_generate_errors_report(
+            self.errors,
+            self.format_file,
+            self.format_key,
+            self.format_error_message,
+            self.format_definition,
+        )
 
     def generate_data_report(
         self,
@@ -96,6 +118,12 @@ class TomlColorReporter(BaseColorReporter):
         """Generate data report in TOML format with colors."""
         report = ""
         if data_key == "config":
+            report += (
+                f'{self.format_config_key("cache")}'
+                f' {self.format_metachar("=")}'
+                f' {self.format_config_value(json.dumps(data["cache"]))}\n'
+            )
+
             report += (
                 f"{self.format_config_key('style')}"
                 f" {self.format_metachar('=')}"
@@ -112,12 +140,6 @@ class TomlColorReporter(BaseColorReporter):
                 report += (
                     f' {self.format_config_value(json.dumps(data["style"]))}\n'
                 )
-
-            report += (
-                f'{self.format_config_key("cache")}'
-                f' {self.format_metachar("=")}'
-                f' {self.format_config_value(json.dumps(data["cache"]))}\n'
-            )
         else:
             plugins = data.pop("plugins", [])
             if plugins:
@@ -141,60 +163,86 @@ class TomlColorReporter(BaseColorReporter):
                     report += self.format_metachar("]")
                 report += "\n\n"
 
-            for rule in data.pop("rules"):
-                report += (
-                    f'{self.format_metachar("[[")}'
-                    f'{self.format_config_key("rules")}'
-                    f'{self.format_metachar("]]")}\n'
-                )
-
-                files = rule.pop("files")
-                report += (
-                    f'{self.format_key("files")} {self.format_metachar("=")} '
-                )
-                if "not" in files and len(files) == 1:
-                    if isinstance(files["not"], dict):
-                        report += f'{self.format_metachar("{")}\n'
-                        for file, reason in files["not"].items():
-                            json_reason = json.dumps(reason)
-                            report += (
-                                f"  {self.format_file(json.dumps(file))}"
-                                f' {self.format_metachar("=")}'
-                                f" {self.format_config_value(json_reason)}"
-                                f'{self.format_metachar(",")}\n'
-                            )
-                        report += f'{self.format_metachar("}")}'
-                    else:
-                        report += f'{self.format_metachar("[")}\n'
-                        for file in files["not"]:
-                            report += (
-                                f"  {self.format_file(json.dumps(file))}"
-                                f'{self.format_metachar(",")}\n'
-                            )
-                        report += f'{self.format_metachar("]")}'
-                else:
-                    report += f'{self.format_metachar("[")}\n'
-                    for file in files:
-                        report += (
-                            f"  {self.format_file(json.dumps(file))}"
-                            f'{self.format_metachar(",")}\n'
-                        )
-                    report += f'{self.format_metachar("]")}'
-                report += "\n"
-
-                for action_index, (action_name, action_value) in enumerate(
-                    rule.items(),
-                ):
-                    serialized_value = _toml_dump_flow_style(action_value)
-                    report += (
-                        f"{self.format_key(action_name)}"
-                        f' {self.format_metachar("=")}'
-                        f" {self.format_config_value(serialized_value)}"
-                    )
-                    if action_index < len(rule) - 1:
-                        report += "\n"
-                report += "\n"
-                if rule:
+            context = None
+            for line in tomli_w.dumps(
+                _replace_nulls_by_repr_strings_in_dict(data),
+            ).splitlines():
+                if not line:
                     report += "\n"
+                elif line.startswith("[[") and line.endswith("]]"):
+                    report += (
+                        f"{self.format_metachar('[[')}"
+                        f"{self.format_config_key(line[2:-2])}"
+                        f"{self.format_metachar(']]')}\n"
+                    )
+                elif line.startswith("[") and line.endswith("]"):
+                    points_after_rules = self.format_metachar(".").join(
+                        [
+                            self.format_key(action)
+                            for action in line[1:-1].split(".")[1:]
+                        ],
+                    )
+                    report += (
+                        f"{self.format_metachar('[')}"
+                        f"{self.format_config_key('rules')}"
+                        f"{self.format_metachar('.')}"
+                        f"{points_after_rules}"
+                        f"{self.format_metachar(']')}\n"
+                    )
 
-        return report
+                    actions_end = line.rstrip("]")
+                    if actions_end.endswith(("files", "files.not")):
+                        context = "files"
+                    else:
+                        context = "action"
+                elif line.startswith("files ="):
+                    report += (
+                        f"{self.format_key('files')}"
+                        f" {self.format_metachar('=')}"
+                        f" {self.format_metachar(line[8:])}\n"
+                    )
+                    context = "files"
+                elif line[0].isalpha():
+                    key, value = line.split("=", maxsplit=1)
+                    report += (
+                        f"{self.format_key(key.strip())}"
+                        f" {self.format_metachar('=')}"
+                        f" {self.format_config_value(value.strip())}\n"
+                    )
+                    context = "action"
+                elif not line.startswith("    "):
+                    if len(line) == 1:  # end of action like ']'
+                        formatter = (
+                            self.format_metachar
+                            if context == "files"
+                            else self.format_config_value
+                        )
+                        report += f"{formatter(line)}\n"
+                    else:
+                        if context == "files":
+                            # files: not
+                            #
+                            # file = reason
+                            file, reason = line.split("=", maxsplit=1)
+                            report += (
+                                f"{self.format_file(file.strip())}"
+                                f" {self.format_metachar('=')}"
+                                f" {self.format_config_value(reason.strip())}\n"
+                            )
+                        else:
+                            report += f"{self.format_config_value(line)}\n"
+                elif context == "files":
+                    indent = len(line) - len(line.lstrip())
+                    report += (
+                        f"{' ' * indent}"
+                        f"{self.format_file(line[indent:-1])}"
+                        f"{self.format_metachar(line[-1])}\n"
+                    )
+                else:  # context == "action"
+                    indent = len(line) - len(line.lstrip())
+                    report += (
+                        f"{' ' * indent}"
+                        f"{self.format_config_value(line[indent:])}\n"
+                    )
+
+        return _normalize_indentation_to_2_spaces(report)

--- a/src/project_config/reporters/yaml.py
+++ b/src/project_config/reporters/yaml.py
@@ -3,7 +3,7 @@
 import typing as t
 
 from project_config.reporters.base import BaseColorReporter, BaseReporter
-from project_config.serializers.yaml import dumps as yaml_dumps
+from project_config.serializers import yaml
 
 
 class YamlReporter(BaseReporter):
@@ -11,35 +11,42 @@ class YamlReporter(BaseReporter):
 
     def generate_errors_report(self) -> str:
         """Generate an errors report in black/white YAML format."""
-        report = ""
-        for line in yaml_dumps(self.errors).splitlines():
-            if line.startswith(("- ", "  ")):
-                report += f"  {line}\n"
-            else:
-                report += f"{line}\n"
-        return report
+        if not self.errors:
+            return ""
+
+        return yaml.dumps(self.errors).rstrip("\n")
+
+    def generate_data_report(
+        self,
+        data_key: str,
+        data: t.Dict[str, t.Any],
+    ) -> str:
+        """Generate a data report in black/white JSON format."""
+        report = yaml.dumps(data)
+        if report.startswith("plugins: []"):
+            report = "\n".join(report.splitlines()[1:])
+        return report.rstrip("\n")
 
 
 class YamlColorReporter(BaseColorReporter):
     """Color reporter in YAML format."""
 
-    def generate_errors_report(self) -> t.Any:
-        """Generate an errors report in YAML format with colors."""
+    def _transform_errors(self, value: str) -> str:
         report = ""
-        for line in yaml_dumps(self.errors).splitlines():
-            if line.startswith("- "):  # definition
+        for line in value.splitlines():
+            if line.startswith("  - "):  # definition
                 report += (
                     f'  {self.format_metachar("-")}'
                     f' {self.format_key("definition")}'
                     f'{self.format_metachar(":")}'
-                    f" {self.format_definition(line[15:])}\n"
+                    f" {self.format_definition(line[16:])}\n"
                 )
-            elif line.startswith("  "):  # message
+            elif line.startswith("    "):  # message
                 report += (
                     f"   "
                     f' {self.format_key("message")}'
                     f'{self.format_metachar(":")}'
-                    f" {self.format_error_message(line[11:])}\n"
+                    f" {self.format_error_message(line[13:])}\n"
                 )
             elif line:
                 report += (
@@ -47,3 +54,110 @@ class YamlColorReporter(BaseColorReporter):
                     f"{self.format_metachar(':')}\n"
                 )
         return report.rstrip("\n")
+
+    def generate_errors_report(self) -> t.Any:
+        """Generate an errors report in YAML format with colors."""
+        if not self.errors:
+            return ""
+
+        return yaml.dumps(self.errors, transform=self._transform_errors)
+
+    def _transform_config_data(self, value: str) -> str:
+        report = ""
+        for line in value.splitlines():
+            if line.startswith("  - "):
+                report += (
+                    f'  {self.format_metachar("-")}'
+                    f" {self.format_config_value(line[4:].strip())}"
+                )
+            else:
+                # key: value
+                key, value = line.split(":", maxsplit=1)
+                report += (
+                    f"{self.format_config_key(key)}"
+                    f"{self.format_metachar(':')}"
+                    f" {self.format_config_value(value.strip())}"
+                ).rstrip()
+            report += "\n"
+        return report.rstrip("\n")
+
+    def _transform_style_data(self, value: str) -> str:
+        report = ""
+
+        section, subsection = None, None
+
+        def format_section(section_name: str) -> str:
+            return (
+                f"{self.format_config_key(section_name)}"
+                f"{self.format_metachar(':')}"
+            )
+
+        for line in value.splitlines():
+            if line.startswith("plugins:"):
+                if line.endswith("[]"):
+                    continue
+                else:
+                    report += format_section("plugins")
+                    section = "plugins"
+            elif line.startswith("rules:"):
+                report += format_section("rules")
+                section = "rules"
+            elif section == "plugins":
+                report += (
+                    f'  {self.format_metachar("-")}'
+                    f" {self.format_config_value(line[4:].strip())}"
+                )
+            elif section == "rules":
+                if line.startswith("  - "):  # files or action
+                    report += (
+                        f'  {self.format_metachar("-")}'
+                        f" {self.format_key(line[4:-1])}"
+                        f'{self.format_metachar(":")}'
+                    )
+                    subsection = (
+                        "files" if line.endswith("files:") else "action"
+                    )
+                elif line.startswith("      "):  # subsection
+                    if subsection == "files":
+                        if line == "      not:":
+                            report += (
+                                f"      {self.format_key('not')}"
+                                f"{self.format_metachar(':')}"
+                            )
+                        elif line.lstrip().startswith("- "):  # file
+                            offset, file = line.split("-", maxsplit=1)
+                            report += (
+                                f"{offset}{self.format_metachar('-')}"
+                                f" {self.format_file(file.strip())}"
+                            )
+                        else:  # not: file
+                            report += (
+                                f"        {self.format_file(line.strip())}"
+                            )
+                    else:
+                        # actions
+                        report += self.format_config_value(line)
+                elif line.startswith("    "):
+                    report += (
+                        f"    {self.format_key(line[4:-1])}"
+                        f'{self.format_metachar(":")}'
+                    )
+                    subsection = (
+                        "files" if line.endswith("files:") else "action"
+                    )
+            report += "\n"
+        return report.rstrip("\n")
+
+    def generate_data_report(
+        self,
+        data_key: str,
+        data: t.Dict[str, t.Any],
+    ) -> str:
+        """Generate a data report in color YAML format."""
+        return yaml.dumps(
+            data,
+            transform=getattr(
+                self,
+                f"_transform_{data_key}_data",
+            ),
+        )

--- a/src/project_config/serializers/yaml.py
+++ b/src/project_config/serializers/yaml.py
@@ -7,13 +7,17 @@ import ruamel.yaml
 
 
 def dumps(
-    obj: t.Dict[str, t.Any], *args: t.Tuple[t.Any], **kwargs: t.Any
+    obj: t.Dict[str, t.Any],
+    *args: t.Tuple[t.Any],
+    **kwargs: t.Any,
 ) -> str:
-    """Deserializes a JSON object converting to string in YAML format."""
+    """Deserializes an object converting it to string in YAML format."""
     f = io.StringIO()
-    kws = {"default_flow_style": False, "width": 88888}
-    kws.update(kwargs)
-    ruamel.yaml.safe_dump(obj, f, *args, **kws)
+    yaml = ruamel.yaml.YAML(typ="safe", pure=True)
+    yaml.default_flow_style = False
+    yaml.width = 88888
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.dump(obj, f, *args, **kwargs)
     return f.getvalue()
 
 

--- a/src/project_config/tests/pytest_plugin/__init__.py
+++ b/src/project_config/tests/pytest_plugin/__init__.py
@@ -6,14 +6,14 @@ import pytest
 pytest.register_assert_rewrite("project_config.tests.pytest_plugin.plugin")
 
 from project_config.tests.pytest_plugin.plugin import (  # noqa: E402
-    _create_files,
-    _create_tree,
+    project_config_data_report_asserter,
+    project_config_errors_report_asserter,
     project_config_plugin_action_asserter,
 )
 
 
 __all__ = (
-    "_create_files",
-    "_create_tree",
+    "project_config_data_report_asserter",
+    "project_config_errors_report_asserter",
     "project_config_plugin_action_asserter",
 )

--- a/src/project_config/tests/pytest_plugin/helpers.py
+++ b/src/project_config/tests/pytest_plugin/helpers.py
@@ -1,0 +1,71 @@
+"""Pytest plugin helpers."""
+
+import os
+import pathlib
+import types
+import typing as t
+
+from project_config.compat import TypeAlias
+from project_config.tree import Tree
+
+
+FilesType: TypeAlias = t.Dict[str, t.Optional[t.Union[str, bool]]]
+RootdirType: TypeAlias = t.Union[str, pathlib.Path]
+
+
+def create_files(files: FilesType, rootdir: RootdirType) -> None:  # noqa: D103
+    if isinstance(rootdir, pathlib.Path):
+        rootdir = str(rootdir)
+    for fpath, content in files.items():
+        if content is False:
+            continue
+        full_path = os.path.join(rootdir, fpath)
+
+        if content is None:
+            os.mkdir(full_path)
+        else:
+            content = t.cast(str, content)
+            # ensure parent path directory exists
+            parent_fpath, _ = os.path.splitext(full_path)
+            if parent_fpath:
+                os.makedirs(parent_fpath, exist_ok=True)
+            with open(full_path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+
+def create_tree(  # noqa: D103
+    files: FilesType,
+    rootdir: RootdirType,
+    cache_files: bool = False,
+) -> Tree:
+    create_files(files, rootdir)
+    tree = Tree(str(rootdir))
+    if cache_files:
+        tree.cache_files(list(files))
+    return tree
+
+
+def get_reporter_class_from_module(  # noqa: D103
+    reporter_module: types.ModuleType,
+    color: bool,
+) -> type:
+    for object_name in dir(reporter_module):
+        if object_name.startswith(("_", "Base")):
+            continue
+        if (color and "ColorReporter" in object_name) or (
+            not color
+            and "Reporter" in object_name
+            and "ColorReporter" not in object_name
+        ):
+            return getattr(reporter_module, object_name)  # type: ignore
+    raise ValueError(
+        f"No{' color' if color else ''} reporter class found in"
+        f" module '{reporter_module.__name__}'",
+    )
+
+
+__all__ = (
+    "create_files",
+    "create_tree",
+    "get_reporter_class_from_module",
+)

--- a/src/project_config/tests/pytest_plugin/helpers.py
+++ b/src/project_config/tests/pytest_plugin/helpers.py
@@ -13,7 +13,10 @@ FilesType: TypeAlias = t.Dict[str, t.Optional[t.Union[str, bool]]]
 RootdirType: TypeAlias = t.Union[str, pathlib.Path]
 
 
-def create_files(files: FilesType, rootdir: RootdirType) -> None:  # noqa: D103
+def create_files(  # noqa: D103
+    files: FilesType,
+    rootdir: RootdirType,
+) -> None:
     if isinstance(rootdir, pathlib.Path):
         rootdir = str(rootdir)
     for fpath, content in files.items():

--- a/src/project_config/tests/pytest_plugin/plugin.py
+++ b/src/project_config/tests/pytest_plugin/plugin.py
@@ -146,7 +146,9 @@ def project_config_plugin_action_asserter(
 
 
 @pytest.fixture  # type: ignore
-def assert_project_config_plugin_action(tmp_path: pathlib.Path) -> t.Any:
+def assert_project_config_plugin_action(
+    tmp_path: pathlib.Path,
+) -> t.Any:
     """Pytest fixture to assert a plugin action.
 
     Returns a function that can be used to assert a plugin action.

--- a/src/project_config/tests/pytest_plugin/plugin.py
+++ b/src/project_config/tests/pytest_plugin/plugin.py
@@ -236,7 +236,7 @@ def project_config_errors_report_asserter(
     """  # noqa: D417
     BwReporter = get_reporter_class_from_module(reporter_module, color=False)
     bw_reporter = BwReporter(str(rootdir))
-    for error in errors:
+    for error in copy.deepcopy(errors):
         if "file" in error:
             error["file"] = str(rootdir / error["file"])
         bw_reporter.report_error(error)
@@ -244,7 +244,10 @@ def project_config_errors_report_asserter(
 
     ColorReporter = get_reporter_class_from_module(reporter_module, color=True)
     color_reporter = ColorReporter(str(rootdir))
-    color_reporter.errors = bw_reporter.errors
+    for error in copy.deepcopy(errors):
+        if "file" in error:
+            error["file"] = str(rootdir / error["file"])
+        color_reporter.report_error(error)
     monkeypatch.setenv("NO_COLOR", "true")  # disable color a moment
     assert color_reporter.generate_errors_report() == expected_result
 

--- a/src/project_config/tests/pytest_plugin/plugin.py
+++ b/src/project_config/tests/pytest_plugin/plugin.py
@@ -93,13 +93,11 @@ def project_config_plugin_action_asserter(
            value,
            rule,
            expected_results,
-           tmp_path,
            assert_project_config_plugin_action,
        ):
            assert_project_config_plugin_action(
                IncludePlugin,
                'includeLines',
-               tmp_path,
                files,
                value,
                rule,

--- a/src/project_config/tests/pytest_plugin/plugin.py
+++ b/src/project_config/tests/pytest_plugin/plugin.py
@@ -163,6 +163,7 @@ def project_config_errors_report_asserter(
     reporter_module: types.ModuleType,
     errors: t.List[ErrorDict],
     expected_result: str,
+    fmt: t.Optional[str] = None,
 ) -> None:
     r"""Asserts an error report from a reporter module.
 
@@ -237,7 +238,7 @@ def project_config_errors_report_asserter(
            assert_errors_report(default, errors, expected_result)
     """  # noqa: D417
     BwReporter = get_reporter_class_from_module(reporter_module, color=False)
-    bw_reporter = BwReporter(str(rootdir))
+    bw_reporter = BwReporter(str(rootdir), fmt=fmt)
     for error in copy.deepcopy(errors):
         if "file" in error:
             error["file"] = str(rootdir / error["file"])
@@ -245,7 +246,7 @@ def project_config_errors_report_asserter(
     assert bw_reporter.generate_errors_report() == expected_result
 
     ColorReporter = get_reporter_class_from_module(reporter_module, color=True)
-    color_reporter = ColorReporter(str(rootdir))
+    color_reporter = ColorReporter(str(rootdir), fmt=fmt)
     for error in copy.deepcopy(errors):
         if "file" in error:
             error["file"] = str(rootdir / error["file"])
@@ -279,6 +280,7 @@ def project_config_data_report_asserter(
     data_key: str,
     data: t.Any,
     expected_result: str,
+    fmt: t.Optional[str] = None,
 ) -> None:
     r"""Asserts a data report from a reporter module.
 
@@ -347,7 +349,7 @@ def project_config_data_report_asserter(
            )
     """  # noqa: D417
     BwReporter = get_reporter_class_from_module(reporter_module, color=False)
-    bw_reporter = BwReporter(str(rootdir))
+    bw_reporter = BwReporter(str(rootdir), fmt=fmt)
     assert (
         bw_reporter.generate_data_report(
             data_key,
@@ -357,7 +359,7 @@ def project_config_data_report_asserter(
     )
 
     ColorReporter = get_reporter_class_from_module(reporter_module, color=True)
-    color_reporter = ColorReporter(str(rootdir))
+    color_reporter = ColorReporter(str(rootdir), fmt=fmt)
     monkeypatch.setenv("NO_COLOR", "true")
     assert (
         color_reporter.generate_data_report(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,10 @@ import time
 import pytest
 from contextlib_chdir import chdir as chdir_ctx
 
-from project_config.tests.pytest_plugin import _create_files, _create_tree
+from project_config.tests.pytest_plugin.helpers import (
+    create_files as _create_files,
+    create_tree as _create_tree,
+)
 from project_config.utils import GET, HTTPError
 
 

--- a/tests/test_unit/test_plugins/test_include.py
+++ b/tests/test_unit/test_plugins/test_include.py
@@ -70,13 +70,11 @@ def test_includeLines(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         IncludePlugin,
         "includeLines",
-        tmp_path,
         files,
         value,
         rule,
@@ -195,13 +193,11 @@ def test_ifIncludeLines(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         IncludePlugin,
         "ifIncludeLines",
-        tmp_path,
         files,
         value,
         rule,
@@ -268,13 +264,11 @@ def test_excludeContent(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         IncludePlugin,
         "excludeContent",
-        tmp_path,
         files,
         value,
         rule,

--- a/tests/test_unit/test_plugins/test_jmespath.py
+++ b/tests/test_unit/test_plugins/test_jmespath.py
@@ -219,13 +219,11 @@ def test_JMESPathsMatch(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         JMESPathPlugin,
         "JMESPathsMatch",
-        tmp_path,
         files,
         value,
         rule,
@@ -358,13 +356,11 @@ def test_JMESPath_custom_functions(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         JMESPathPlugin,
         "JMESPathsMatch",
-        tmp_path,
         files,
         value,
         rule,
@@ -612,13 +608,11 @@ def test_ifJMESPathsMatch(
     value,
     rule,
     expected_results,
-    tmp_path,
     assert_project_config_plugin_action,
 ):
     assert_project_config_plugin_action(
         JMESPathPlugin,
         "ifJMESPathsMatch",
-        tmp_path,
         files,
         value,
         rule,

--- a/tests/test_unit/test_reporters/test_default_reporter.py
+++ b/tests/test_unit/test_reporters/test_default_reporter.py
@@ -49,7 +49,7 @@ bar.py
         ),
     ),
 )
-def test_default_errors_report(errors, expected_result, assert_errors_report):
+def test_errors_report(errors, expected_result, assert_errors_report):
     assert_errors_report(default, errors, expected_result)
 
 
@@ -179,7 +179,7 @@ rules:
         ),
     ),
 )
-def test_default_data_report(
+def test_data_report(
     data_key,
     data,
     expected_result,

--- a/tests/test_unit/test_reporters/test_default_reporter.py
+++ b/tests/test_unit/test_reporters/test_default_reporter.py
@@ -1,15 +1,8 @@
-import copy
-
 import pytest
-from testing_helpers import parametrize_color
 
-from project_config.reporters.default import (
-    DefaultColorReporter,
-    DefaultReporter,
-)
+from project_config.reporters import default
 
 
-@parametrize_color
 @pytest.mark.parametrize(
     ("errors", "expected_result"),
     (
@@ -56,27 +49,10 @@ bar.py
         ),
     ),
 )
-def test_default_errors_report(
-    color,
-    errors,
-    expected_result,
-    tmp_path,
-    monkeypatch,
-):
-    reporter = (DefaultColorReporter if color else DefaultReporter)(
-        str(tmp_path),
-    )
-    for error in errors:
-        if "file" in error:
-            error["file"] = str(tmp_path / error["file"])
-        reporter.report_error(error)
-
-    if color:
-        monkeypatch.setenv("NO_COLOR", "true")  # disable color a moment
-    assert reporter.generate_errors_report() == expected_result
+def test_default_errors_report(errors, expected_result, assert_errors_report):
+    assert_errors_report(default, errors, expected_result)
 
 
-@parametrize_color
 @pytest.mark.parametrize(
     ("data_key", "data", "expected_result"),
     (
@@ -209,23 +185,14 @@ rules:
     ),
 )
 def test_default_data_report(
-    color,
     data_key,
     data,
     expected_result,
-    tmp_path,
-    monkeypatch,
+    assert_data_report,
 ):
-    reporter = (DefaultColorReporter if color else DefaultReporter)(
-        str(tmp_path),
-    )
-
-    if color:
-        monkeypatch.setenv("NO_COLOR", "true")
-    assert (
-        reporter.generate_data_report(
-            data_key,
-            copy.deepcopy(data),  # data is manipulated inplace
-        )
-        == expected_result
+    assert_data_report(
+        default,
+        data_key,
+        data,
+        expected_result,
     )

--- a/tests/test_unit/test_reporters/test_default_reporter.py
+++ b/tests/test_unit/test_reporters/test_default_reporter.py
@@ -1,8 +1,15 @@
+import copy
+
 import pytest
+from testing_helpers import parametrize_color
 
-from project_config.reporters.default import DefaultReporter
+from project_config.reporters.default import (
+    DefaultColorReporter,
+    DefaultReporter,
+)
 
 
+@parametrize_color
 @pytest.mark.parametrize(
     ("errors", "expected_result"),
     (
@@ -49,15 +56,27 @@ bar.py
         ),
     ),
 )
-def test_default_errors_report(errors, expected_result, tmp_path):
-    reporter = DefaultReporter(str(tmp_path))
+def test_default_errors_report(
+    color,
+    errors,
+    expected_result,
+    tmp_path,
+    monkeypatch,
+):
+    reporter = (DefaultColorReporter if color else DefaultReporter)(
+        str(tmp_path),
+    )
     for error in errors:
         if "file" in error:
             error["file"] = str(tmp_path / error["file"])
         reporter.report_error(error)
+
+    if color:
+        monkeypatch.setenv("NO_COLOR", "true")  # disable color a moment
     assert reporter.generate_errors_report() == expected_result
 
 
+@parametrize_color
 @pytest.mark.parametrize(
     ("data_key", "data", "expected_result"),
     (
@@ -189,12 +208,24 @@ rules:
         ),
     ),
 )
-def test_default_data_report(data_key, data, expected_result, tmp_path):
-    reporter = DefaultReporter(str(tmp_path))
+def test_default_data_report(
+    color,
+    data_key,
+    data,
+    expected_result,
+    tmp_path,
+    monkeypatch,
+):
+    reporter = (DefaultColorReporter if color else DefaultReporter)(
+        str(tmp_path),
+    )
+
+    if color:
+        monkeypatch.setenv("NO_COLOR", "true")
     assert (
         reporter.generate_data_report(
             data_key,
-            data,
+            copy.deepcopy(data),  # data is manipulated inplace
         )
         == expected_result
     )

--- a/tests/test_unit/test_reporters/test_json_reporter.py
+++ b/tests/test_unit/test_reporters/test_json_reporter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from project_config.reporters import default
+from project_config.reporters import json
 
 
 @pytest.mark.parametrize(
@@ -8,7 +8,7 @@ from project_config.reporters import default
     (
         pytest.param(
             [],
-            "",
+            "{}",
             id="ok",
         ),
         pytest.param(
@@ -19,7 +19,7 @@ from project_config.reporters import default
                     "definition": "definition",
                 },
             ],
-            "foo.py\n  - message definition",
+            '{"foo.py": [{"message": "message", "definition": "definition"}]}',
             id="basic",
         ),
         pytest.param(
@@ -40,17 +40,23 @@ from project_config.reporters import default
                     "definition": "definition 3",
                 },
             ],
-            """foo.py
-  - message 1 definition 1
-  - message 2 definition 2
-bar.py
-  - message 3 definition 3""",
+            (
+                '{"foo.py": [{"message": "message 1", "definition":'
+                ' "definition 1"}, {"message": "message 2",'
+                ' "definition": "definition 2"}], "bar.py":'
+                ' [{"message": "message 3", "definition":'
+                ' "definition 3"}]}'
+            ),
             id="complex",
         ),
     ),
 )
-def test_default_errors_report(errors, expected_result, assert_errors_report):
-    assert_errors_report(default, errors, expected_result)
+def test_json_reporter(
+    errors,
+    expected_result,
+    assert_errors_report,
+):
+    assert_errors_report(json, errors, expected_result)
 
 
 @pytest.mark.parametrize(
@@ -62,8 +68,7 @@ def test_default_errors_report(errors, expected_result, assert_errors_report):
                 "cache": "5 minutes",
                 "style": "foo.json5",
             },
-            """cache: 5 minutes
-style: foo.json5""",
+            '{"cache": "5 minutes", "style": "foo.json5"}',
             id="config-style-string",
         ),
         pytest.param(
@@ -72,10 +77,7 @@ style: foo.json5""",
                 "cache": "5 minutes",
                 "style": ["foo.json5", "bar.json5"],
             },
-            """cache: 5 minutes
-style:
-  - foo.json5
-  - bar.json5""",
+            '{"cache": "5 minutes", "style": ["foo.json5", "bar.json5"]}',
             id="config-style-array",
         ),
         pytest.param(
@@ -87,10 +89,7 @@ style:
                     },
                 ],
             },
-            """rules:
-  - files:
-      - foo.ext
-      - bar.ext""",
+            '{"rules": [{"files": ["foo.ext", "bar.ext"]}]}',
             id="style-basic",
         ),
         pytest.param(
@@ -107,20 +106,11 @@ style:
                     },
                 ],
             },
-            """plugins:
-  - plugin_foo
-rules:
-  - files:
-      - foo.ext
-      - bar.ext
-  - files:
-      - foo.ext
-      - bar.ext
-    includeLines:
-      [
-        "line1",
-        "line2"
-      ]""",
+            (
+                '{"plugins": ["plugin_foo"], "rules": [{"files":'
+                ' ["foo.ext", "bar.ext"]}, {"files": ["foo.ext",'
+                ' "bar.ext"], "includeLines": ["line1", "line2"]}]}'
+            ),
             id="style-multiple-rules",
         ),
         pytest.param(
@@ -148,45 +138,26 @@ rules:
                     },
                 ],
             },
-            """plugins:
-  - plugin_foo
-  - plugin_bar
-rules:
-  - files:
-      - foo.ext
-      - bar.ext
-  - files:
-      not
-        foo.ext: foo reason
-        bar.ext: bar reason
-    includeLines:
-      [
-        "line1",
-        "line2"
-      ]
-    ifIncludeLines:
-      {
-        "if-inc-1.ext": [
-          "if-inc-line-1",
-          "if-inc-line-2"
-        ]
-      }
-  - files:
-      not
-        - foo.ext
-        - foo.bar""",
+            (
+                '{"plugins": ["plugin_foo", "plugin_bar"], "rules":'
+                ' [{"files": ["foo.ext", "bar.ext"]}, {"files": {"not":'
+                ' {"foo.ext": "foo reason", "bar.ext": "bar reason"}},'
+                ' "includeLines": ["line1", "line2"], "ifIncludeLines":'
+                ' {"if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"]}},'
+                ' {"files": {"not": ["foo.ext", "foo.bar"]}}]}'
+            ),
             id="style-complex",
         ),
     ),
 )
-def test_default_data_report(
+def test_json_data_report(
     data_key,
     data,
     expected_result,
     assert_data_report,
 ):
     assert_data_report(
-        default,
+        json,
         data_key,
         data,
         expected_result,

--- a/tests/test_unit/test_reporters/test_json_reporter.py
+++ b/tests/test_unit/test_reporters/test_json_reporter.py
@@ -1,164 +1,198 @@
+import json
+
 import pytest
 
-from project_config.reporters import json
+from project_config.reporters import json as json_reporter_module
 
 
+parametrize_formats = pytest.mark.parametrize(
+    "fmt",
+    (None, "pretty", "pretty4"),
+    ids=("format=default", "format=pretty", "format=pretty4"),
+)
+
+ERROR_REPORTS_PARAMETERS = (
+    pytest.param(
+        [],
+        "{}",
+        id="ok",
+    ),
+    pytest.param(
+        [
+            {
+                "file": "foo.py",
+                "message": "message",
+                "definition": "definition",
+            },
+        ],
+        '{"foo.py": [{"message": "message", "definition": "definition"}]}',
+        id="basic",
+    ),
+    pytest.param(
+        [
+            {
+                "file": "foo.py",
+                "message": "message 1",
+                "definition": "definition 1",
+            },
+            {
+                "file": "foo.py",
+                "message": "message 2",
+                "definition": "definition 2",
+            },
+            {
+                "file": "bar.py",
+                "message": "message 3",
+                "definition": "definition 3",
+            },
+        ],
+        (
+            '{"foo.py": [{"message": "message 1", "definition":'
+            ' "definition 1"}, {"message": "message 2",'
+            ' "definition": "definition 2"}], "bar.py":'
+            ' [{"message": "message 3", "definition":'
+            ' "definition 3"}]}'
+        ),
+        id="complex",
+    ),
+)
+
+DATA_REPORTS_PARAMETERS = (
+    pytest.param(
+        "config",
+        {
+            "cache": "5 minutes",
+            "style": "foo.json5",
+        },
+        '{"cache": "5 minutes", "style": "foo.json5"}',
+        id="config-style-string",
+    ),
+    pytest.param(
+        "config",
+        {
+            "cache": "5 minutes",
+            "style": ["foo.json5", "bar.json5"],
+        },
+        '{"cache": "5 minutes", "style": ["foo.json5", "bar.json5"]}',
+        id="config-style-array",
+    ),
+    pytest.param(
+        "style",
+        {
+            "rules": [
+                {
+                    "files": ["foo.ext", "bar.ext"],
+                },
+            ],
+        },
+        '{"rules": [{"files": ["foo.ext", "bar.ext"]}]}',
+        id="style-basic",
+    ),
+    pytest.param(
+        "style",
+        {
+            "plugins": ["plugin_foo"],
+            "rules": [
+                {
+                    "files": ["foo.ext", "bar.ext"],
+                },
+                {
+                    "files": ["foo.ext", "bar.ext"],
+                    "includeLines": ["line1", "line2"],
+                },
+            ],
+        },
+        (
+            '{"plugins": ["plugin_foo"], "rules": [{"files":'
+            ' ["foo.ext", "bar.ext"]}, {"files": ["foo.ext",'
+            ' "bar.ext"], "includeLines": ["line1", "line2"]}]}'
+        ),
+        id="style-multiple-rules",
+    ),
+    pytest.param(
+        "style",
+        {
+            "plugins": ["plugin_foo", "plugin_bar"],
+            "rules": [
+                {
+                    "files": ["foo.ext", "bar.ext"],
+                },
+                {
+                    "files": {
+                        "not": {
+                            "foo.ext": "foo reason",
+                            "bar.ext": "bar reason",
+                        },
+                    },
+                    "includeLines": ["line1", "line2"],
+                    "ifIncludeLines": {
+                        "if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"],
+                    },
+                },
+                {
+                    "files": {"not": ["foo.ext", "foo.bar"]},
+                },
+            ],
+        },
+        (
+            '{"plugins": ["plugin_foo", "plugin_bar"], "rules":'
+            ' [{"files": ["foo.ext", "bar.ext"]}, {"files": {"not":'
+            ' {"foo.ext": "foo reason", "bar.ext": "bar reason"}},'
+            ' "includeLines": ["line1", "line2"], "ifIncludeLines":'
+            ' {"if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"]}},'
+            ' {"files": {"not": ["foo.ext", "foo.bar"]}}]}'
+        ),
+        id="style-complex",
+    ),
+)
+
+
+def _expected_result_by_format(expected_result, fmt):
+    if fmt == "pretty":
+        expected_result = json.dumps(json.loads(expected_result), indent=2)
+    elif fmt == "pretty4":
+        expected_result = json.dumps(
+            json.loads(expected_result),
+            indent=4,
+        )
+    return expected_result
+
+
+@parametrize_formats
 @pytest.mark.parametrize(
     ("errors", "expected_result"),
-    (
-        pytest.param(
-            [],
-            "{}",
-            id="ok",
-        ),
-        pytest.param(
-            [
-                {
-                    "file": "foo.py",
-                    "message": "message",
-                    "definition": "definition",
-                },
-            ],
-            '{"foo.py": [{"message": "message", "definition": "definition"}]}',
-            id="basic",
-        ),
-        pytest.param(
-            [
-                {
-                    "file": "foo.py",
-                    "message": "message 1",
-                    "definition": "definition 1",
-                },
-                {
-                    "file": "foo.py",
-                    "message": "message 2",
-                    "definition": "definition 2",
-                },
-                {
-                    "file": "bar.py",
-                    "message": "message 3",
-                    "definition": "definition 3",
-                },
-            ],
-            (
-                '{"foo.py": [{"message": "message 1", "definition":'
-                ' "definition 1"}, {"message": "message 2",'
-                ' "definition": "definition 2"}], "bar.py":'
-                ' [{"message": "message 3", "definition":'
-                ' "definition 3"}]}'
-            ),
-            id="complex",
-        ),
-    ),
+    ERROR_REPORTS_PARAMETERS,
 )
 def test_json_reporter(
     errors,
     expected_result,
+    fmt,
     assert_errors_report,
 ):
-    assert_errors_report(json, errors, expected_result)
+    assert_errors_report(
+        json_reporter_module,
+        errors,
+        _expected_result_by_format(expected_result, fmt),
+        fmt=fmt,
+    )
 
 
+@parametrize_formats
 @pytest.mark.parametrize(
     ("data_key", "data", "expected_result"),
-    (
-        pytest.param(
-            "config",
-            {
-                "cache": "5 minutes",
-                "style": "foo.json5",
-            },
-            '{"cache": "5 minutes", "style": "foo.json5"}',
-            id="config-style-string",
-        ),
-        pytest.param(
-            "config",
-            {
-                "cache": "5 minutes",
-                "style": ["foo.json5", "bar.json5"],
-            },
-            '{"cache": "5 minutes", "style": ["foo.json5", "bar.json5"]}',
-            id="config-style-array",
-        ),
-        pytest.param(
-            "style",
-            {
-                "rules": [
-                    {
-                        "files": ["foo.ext", "bar.ext"],
-                    },
-                ],
-            },
-            '{"rules": [{"files": ["foo.ext", "bar.ext"]}]}',
-            id="style-basic",
-        ),
-        pytest.param(
-            "style",
-            {
-                "plugins": ["plugin_foo"],
-                "rules": [
-                    {
-                        "files": ["foo.ext", "bar.ext"],
-                    },
-                    {
-                        "files": ["foo.ext", "bar.ext"],
-                        "includeLines": ["line1", "line2"],
-                    },
-                ],
-            },
-            (
-                '{"plugins": ["plugin_foo"], "rules": [{"files":'
-                ' ["foo.ext", "bar.ext"]}, {"files": ["foo.ext",'
-                ' "bar.ext"], "includeLines": ["line1", "line2"]}]}'
-            ),
-            id="style-multiple-rules",
-        ),
-        pytest.param(
-            "style",
-            {
-                "plugins": ["plugin_foo", "plugin_bar"],
-                "rules": [
-                    {
-                        "files": ["foo.ext", "bar.ext"],
-                    },
-                    {
-                        "files": {
-                            "not": {
-                                "foo.ext": "foo reason",
-                                "bar.ext": "bar reason",
-                            },
-                        },
-                        "includeLines": ["line1", "line2"],
-                        "ifIncludeLines": {
-                            "if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"],
-                        },
-                    },
-                    {
-                        "files": {"not": ["foo.ext", "foo.bar"]},
-                    },
-                ],
-            },
-            (
-                '{"plugins": ["plugin_foo", "plugin_bar"], "rules":'
-                ' [{"files": ["foo.ext", "bar.ext"]}, {"files": {"not":'
-                ' {"foo.ext": "foo reason", "bar.ext": "bar reason"}},'
-                ' "includeLines": ["line1", "line2"], "ifIncludeLines":'
-                ' {"if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"]}},'
-                ' {"files": {"not": ["foo.ext", "foo.bar"]}}]}'
-            ),
-            id="style-complex",
-        ),
-    ),
+    DATA_REPORTS_PARAMETERS,
 )
 def test_json_data_report(
     data_key,
     data,
     expected_result,
+    fmt,
     assert_data_report,
 ):
     assert_data_report(
-        json,
+        json_reporter_module,
         data_key,
         data,
-        expected_result,
+        _expected_result_by_format(expected_result, fmt),
+        fmt=fmt,
     )

--- a/tests/test_unit/test_reporters/test_json_reporter.py
+++ b/tests/test_unit/test_reporters/test_json_reporter.py
@@ -163,7 +163,7 @@ def _expected_result_by_format(expected_result, fmt):
     ("errors", "expected_result"),
     ERROR_REPORTS_PARAMETERS,
 )
-def test_json_reporter(
+def test_errors_report(
     errors,
     expected_result,
     fmt,
@@ -182,7 +182,7 @@ def test_json_reporter(
     ("data_key", "data", "expected_result"),
     DATA_REPORTS_PARAMETERS,
 )
-def test_json_data_report(
+def test_data_report(
     data_key,
     data,
     expected_result,

--- a/tests/test_unit/test_reporters/test_table_reporter.py
+++ b/tests/test_unit/test_reporters/test_table_reporter.py
@@ -1,0 +1,56 @@
+import pytest
+
+from project_config.reporters import table
+
+
+@pytest.mark.parametrize(
+    ("errors", "expected_result"),
+    (
+        pytest.param(
+            [],
+            """files    message    definition
+-------  ---------  ------------""",
+            id="ok",
+        ),
+        pytest.param(
+            [
+                {
+                    "file": "foo.py",
+                    "message": "message",
+                    "definition": "definition",
+                },
+            ],
+            """files    message    definition
+-------  ---------  ------------
+foo.py   message    definition""",
+            id="basic",
+        ),
+        pytest.param(
+            [
+                {
+                    "file": "foo.py",
+                    "message": "message 1",
+                    "definition": "definition 1",
+                },
+                {
+                    "file": "foo.py",
+                    "message": "message 2",
+                    "definition": "definition 2",
+                },
+                {
+                    "file": "bar.py",
+                    "message": "message 3",
+                    "definition": "definition 3",
+                },
+            ],
+            """files    message    definition
+-------  ---------  ------------
+foo.py   message 1  definition 1
+         message 2  definition 2
+bar.py   message 3  definition 3""",
+            id="complex",
+        ),
+    ),
+)
+def test_errors_report(errors, expected_result, assert_errors_report):
+    assert_errors_report(table, errors, expected_result, fmt="simple")

--- a/tests/test_unit/test_reporters/test_yaml_reporter.py
+++ b/tests/test_unit/test_reporters/test_yaml_reporter.py
@@ -1,0 +1,214 @@
+import pytest
+
+from project_config.reporters import yaml
+
+
+@pytest.mark.parametrize(
+    ("errors", "expected_result"),
+    (
+        pytest.param(
+            [],
+            "",
+            id="ok",
+        ),
+        pytest.param(
+            [
+                {
+                    "file": "foo.py",
+                    "message": "message",
+                    "definition": "definition",
+                },
+            ],
+            """foo.py:
+  - definition: definition
+    message: message""",
+            id="basic",
+        ),
+        pytest.param(
+            [
+                {
+                    "file": "foo.py",
+                    "message": "message 1",
+                    "definition": "definition 1",
+                },
+                {
+                    "file": "foo.py",
+                    "message": "message 2",
+                    "definition": "definition 2",
+                },
+                {
+                    "file": "bar.py",
+                    "message": "message 3",
+                    "definition": "definition 3",
+                },
+            ],
+            """bar.py:
+  - definition: definition 3
+    message: message 3
+foo.py:
+  - definition: definition 1
+    message: message 1
+  - definition: definition 2
+    message: message 2""",
+            id="complex",
+        ),
+    ),
+)
+def test_yaml_errors_report(
+    errors,
+    expected_result,
+    assert_errors_report,
+):
+    assert_errors_report(
+        yaml,
+        errors,
+        expected_result,
+    )
+
+
+@pytest.mark.parametrize(
+    ("data_key", "data", "expected_result"),
+    (
+        pytest.param(
+            "config",
+            {
+                "cache": "5 minutes",
+                "style": "foo.json5",
+            },
+            "cache: 5 minutes\nstyle: foo.json5",
+            id="config-style-string",
+        ),
+        pytest.param(
+            "config",
+            {
+                "cache": "5 minutes",
+                "style": ["foo.json5", "bar.json5"],
+            },
+            """cache: 5 minutes
+style:
+  - foo.json5
+  - bar.json5""",
+            id="config-style-array",
+        ),
+        pytest.param(
+            "style",
+            {
+                "rules": [
+                    {
+                        "files": ["foo.ext", "bar.ext"],
+                    },
+                ],
+            },
+            """rules:
+  - files:
+      - foo.ext
+      - bar.ext""",
+            id="style-basic",
+        ),
+        pytest.param(
+            "style",
+            {
+                "plugins": [],
+                "rules": [
+                    {
+                        "files": ["foo.ext", "bar.ext"],
+                    },
+                ],
+            },
+            """rules:
+  - files:
+      - foo.ext
+      - bar.ext""",
+            id="style-empty-plugins",
+        ),
+        pytest.param(
+            "style",
+            {
+                "plugins": ["plugin_foo"],
+                "rules": [
+                    {
+                        "files": ["foo.ext", "bar.ext"],
+                    },
+                    {
+                        "files": ["foo.ext", "bar.ext"],
+                        "includeLines": ["line1", "line2"],
+                    },
+                ],
+            },
+            """plugins:
+  - plugin_foo
+rules:
+  - files:
+      - foo.ext
+      - bar.ext
+  - files:
+      - foo.ext
+      - bar.ext
+    includeLines:
+      - line1
+      - line2""",
+            id="style-multiple-rules",
+        ),
+        pytest.param(
+            "style",
+            {
+                "plugins": ["plugin_foo", "plugin_bar"],
+                "rules": [
+                    {
+                        "files": ["foo.ext", "bar.ext"],
+                    },
+                    {
+                        "files": {
+                            "not": {
+                                "foo.ext": "foo reason",
+                                "bar.ext": "bar reason",
+                            },
+                        },
+                        "includeLines": ["line1", "line2"],
+                        "ifIncludeLines": {
+                            "if-inc-1.ext": ["if-inc-line-1", "if-inc-line-2"],
+                        },
+                    },
+                    {
+                        "files": {"not": ["foo.ext", "foo.bar"]},
+                    },
+                ],
+            },
+            """plugins:
+  - plugin_foo
+  - plugin_bar
+rules:
+  - files:
+      - foo.ext
+      - bar.ext
+  - files:
+      not:
+        bar.ext: bar reason
+        foo.ext: foo reason
+    ifIncludeLines:
+      if-inc-1.ext:
+        - if-inc-line-1
+        - if-inc-line-2
+    includeLines:
+      - line1
+      - line2
+  - files:
+      not:
+        - foo.ext
+        - foo.bar""",
+            id="style-complex",
+        ),
+    ),
+)
+def test_yaml_data_report(
+    data_key,
+    data,
+    expected_result,
+    assert_data_report,
+):
+    assert_data_report(
+        yaml,
+        data_key,
+        data,
+        expected_result,
+    )

--- a/tests/testing_helpers/__init__.py
+++ b/tests/testing_helpers/__init__.py
@@ -20,12 +20,6 @@ mark_end2end = pytest.mark.skipif(
     reason="The environment variable PROJECT_CONFIG_TESTS_E2E is not set",
 )
 
-parametrize_color = pytest.mark.parametrize(
-    "color",
-    (True, False),
-    ids=("color=True", "color=False"),
-)
-
 
 def build_testing_server():
     # do not show Flask server banner

--- a/tests/testing_helpers/__init__.py
+++ b/tests/testing_helpers/__init__.py
@@ -20,6 +20,12 @@ mark_end2end = pytest.mark.skipif(
     reason="The environment variable PROJECT_CONFIG_TESTS_E2E is not set",
 )
 
+parametrize_color = pytest.mark.parametrize(
+    "color",
+    (True, False),
+    ids=("color=True", "color=False"),
+)
+
 
 def build_testing_server():
     # do not show Flask server banner


### PR DESCRIPTION
Resolves #2

Also:

- Add fixtures to pytest plugin for reporters assertion
- Do not need to specify `tmp_path` for root directory testing action plugins with pytest fixtures
- Implement YAML data color reporter
- Bug fixes in TOML color reporter