### PR TITLE
Set environment variable while CLI is running

### DIFF
--- a/docs/in-depth/serialization.rst
+++ b/docs/in-depth/serialization.rst
@@ -124,3 +124,9 @@ executing them.
          {
            "bar": "baz"
          }
+
+.. tip::
+
+   **project-config** CLI sets the environment variable ``PROJECT_CONFIG``
+   while is running, which is useful if you want to expose the global namespaces
+   of scripts only when the tool is running.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -21,6 +21,11 @@ project-config CLI
 * ``project-config show cache`` - Show cache directory location.
 * ``project-config clean cache`` - Clean the persistent cache of remote collected sources.
 
+.. tip::
+
+   **project-config** CLI sets the environment variable ``PROJECT_CONFIG`` while
+   is running.
+
 ..
    .. sphinx_argparse_cli::
       :module: project_config.__main__
@@ -67,7 +72,8 @@ The reporter output affects the output of the next commands:
 .. note::
 
    Colorized output can't be serialized, so if you want to postprocess the report
-   in the command line use always the ``--no-color`` flag.
+   in the command line use always the ``--no-color`` / ``--nocolor`` flag or set
+   the environment variable ``NO_COLOR``.
 
 Additional third party reporters can be implemented as plugins,
 see :ref:`dev/reporters:Writing third party reporters` for more information.

--- a/src/project_config/__main__.py
+++ b/src/project_config/__main__.py
@@ -135,6 +135,7 @@ def _parse_command_args(
 
 
 def run(argv: t.List[str] = []) -> int:  # noqa: D103
+    os.environ["PROJECT_CONFIG"] = "true"
     parser = _build_main_parser()
     args, subcommand_args = parser.parse_known_args(argv)
     subargs, remaining = _parse_command_args(args.command, subcommand_args)


### PR DESCRIPTION
Set environment variable `PROJECT_CONFIG` while the CLI is running.

Resolves #44 