### PR TITLE
Fix two `fix` mode bugs

### DIFF
--- a/examples/012-editorconfig/.editorconfig
+++ b/examples/012-editorconfig/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true

--- a/examples/012-editorconfig/.project-config.toml
+++ b/examples/012-editorconfig/.project-config.toml
@@ -1,0 +1,1 @@
+style = "style.json5"

--- a/examples/012-editorconfig/README.rst
+++ b/examples/012-editorconfig/README.rst
@@ -1,0 +1,7 @@
+..
+   Name: Autofixing a .editorconfig
+   Exitcode: 0
+
+If you run the next example using ``project-config fix`` subcommand
+without creating an `.editorconfig` file it will be created and populated
+with the sections defined in the rule.

--- a/examples/012-editorconfig/style.json5
+++ b/examples/012-editorconfig/style.json5
@@ -1,0 +1,16 @@
+{
+  rules: [
+    {
+      files: [".editorconfig"],
+      JMESPathsMatch: [
+        ["type(@)", "object"],
+        ['type("")', "object"],
+        ['"".root', true],
+        ['"*".end_of_line', "lf"],
+        ['"*".indent_style', "space"],
+        ['"*".charset', "utf-8"],
+        ['"*".trim_trailing_whitespace', true],
+      ],
+    },
+  ],
+}

--- a/examples/_001-basic-usage-fails-file-existence/README.rst
+++ b/examples/_001-basic-usage-fails-file-existence/README.rst
@@ -1,5 +1,4 @@
 ..
    Name: Basic usage
    Exitcode: 1
-   Stderr: .gitignore\n  - Expected existing file does not exists rules[0].files[0]
-   Fixable: true
+   Stderr: .gitignore\n  - (FIXABLE) Expected existing file does not exists rules[0].files[0]

--- a/examples/_003-files-absence-fails/README.rst
+++ b/examples/_003-files-absence-fails/README.rst
@@ -1,6 +1,6 @@
 ..
    Name: Files absence
    Exitcode: 1
-   Stderr: readme.md\n  - Expected absent file exists. Users are more used to seeing README.md file name in uppercase rules[0].files.not[readme.md]\nindex.md\n  - Expected absent file exists rules[1].files.not[0]
+   Stderr: readme.md\n  - (FIXABLE) Expected absent file exists. Users are more used to seeing README.md file name in uppercase rules[0].files.not[readme.md]\nindex.md\n  - (FIXABLE) Expected absent file exists rules[1].files.not[0]
 
 The files `readme.md` and `index.md` must not exist.

--- a/examples/_004-conditionals-fails/README.rst
+++ b/examples/_004-conditionals-fails/README.rst
@@ -1,7 +1,7 @@
 ..
    Name: Conditionals
    Exitcode: 1
-   Stderr: pyproject.toml\n  - Expected existing file does not exists rules[0].files[0]
+   Stderr: pyproject.toml\n  - (FIXABLE) Expected existing file does not exists rules[0].files[0]
 
 If `.gitignore` includes the line ``__pycache__/`` a `pyproject.toml`
 file must be present.

--- a/examples/_005-conditional-files-existence-fails-1/README.rst
+++ b/examples/_005-conditional-files-existence-fails-1/README.rst
@@ -1,7 +1,7 @@
 ..
    Name: Conditionals files existence (fails rule 1)
    Exitcode: 1
-   Stderr: foobarbaz.toml\n  - Expected existing file does not exists rules[0].files[0]
+   Stderr: foobarbaz.toml\n  - (FIXABLE) Expected existing file does not exists rules[0].files[0]
 
 * 1st rule: if the directory `src/` exists, the file `foobarbaz.toml` must exists too.
 * 2nd rule: if the file `pyproject.toml` exists, a Python file must be present in the root directory.

--- a/examples/_005-conditional-files-existence-fails-2/README.rst
+++ b/examples/_005-conditional-files-existence-fails-2/README.rst
@@ -1,7 +1,7 @@
 ..
    Name: Conditionals files existence (fails rule 2)
    Exitcode: 1
-   Stderr: *.py\n  - Expected existing file does not exists rules[1].files[0]
+   Stderr: *.py\n  - (FIXABLE) Expected existing file does not exists rules[1].files[0]
 
 * 1st rule: if the directory `src/` exists, the file `pyproject.toml` must exists too.
 * 2nd rule: if the file `pyproject.toml` exists, a Python file must be present in the root directory.

--- a/examples/_012-editorconfig-fix/.project-config.toml
+++ b/examples/_012-editorconfig-fix/.project-config.toml
@@ -1,0 +1,1 @@
+style = "style.json5"

--- a/examples/_012-editorconfig-fix/README.rst
+++ b/examples/_012-editorconfig-fix/README.rst
@@ -1,0 +1,8 @@
+..
+   Name: Autofixing .editorconfig
+   Exitcode: 1
+   Stderr: .editorconfig\n  - (FIXABLE) JMESPath 'type("")' does not match. Expected 'object', returned 'null' rules[0].JMESPathsMatch[1]\n  - (FIXABLE) JMESPath '"".root' does not match. Expected True, returned None rules[0].JMESPathsMatch[2]\n  - (FIXABLE) JMESPath '"*".end_of_line' does not match. Expected 'lf', returned None rules[0].JMESPathsMatch[3]\n  - (FIXABLE) JMESPath '"*".indent_style' does not match. Expected 'space', returned None rules[0].JMESPathsMatch[4]\n  - (FIXABLE) JMESPath '"*".charset' does not match. Expected 'utf-8', returned None rules[0].JMESPathsMatch[5]\n  - (FIXABLE) JMESPath '"*".trim_trailing_whitespace' does not match. Expected True, returned None rules[0].JMESPathsMatch[6]
+
+If you run the next example using ``project-config fix`` subcommand
+without creating an `.editorconfig` file it will be created and populated
+with the sections defined in the rule.

--- a/examples/_012-editorconfig-fix/style.json5
+++ b/examples/_012-editorconfig-fix/style.json5
@@ -1,0 +1,16 @@
+{
+  rules: [
+    {
+      files: [".editorconfig"],
+      JMESPathsMatch: [
+        ["type(@)", "object"],
+        ['type("")', "object"],
+        ['"".root', true],
+        ['"*".end_of_line', "lf"],
+        ['"*".indent_style', "space"],
+        ['"*".charset', "utf-8"],
+        ['"*".trim_trailing_whitespace', true],
+      ],
+    },
+  ],
+}

--- a/foo/.editorconfig
+++ b/foo/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true

--- a/foo/.project-config.toml
+++ b/foo/.project-config.toml
@@ -1,0 +1,2 @@
+style = ["style.json5"]
+cache = "5 minutes"

--- a/foo/style.json5
+++ b/foo/style.json5
@@ -1,0 +1,22 @@
+{
+  extends: ["../../project-config-styles/base/editorconfig.json5"],
+  rules: [
+    {
+      files: [".project-config.toml"],
+      JMESPathsMatch: [
+        ["type(style)", "array"],
+        [
+          "op(length(style), '>', `0`)",
+          true,
+          "set(@, 'style', ['style.json5'])",
+        ],
+        ["type(cache)", "string", "set(@, 'cache', '5 minutes')"],
+        [
+          "regex_match('(\\d+ ((seconds?)|(minutes?)|(hours?)|(days?)|(weeks?)))|(never)$', cache)",
+          true,
+          "5 minutes",
+        ],
+      ],
+    },
+  ],
+}

--- a/src/project_config/project.py
+++ b/src/project_config/project.py
@@ -130,6 +130,7 @@ class Project:
                         "file": fpath,
                         "definition": f"rules[{rule_index}].files[{f}]",
                         "fixed": self.fix,
+                        "fixable": True,
                     },
                 )
 
@@ -169,6 +170,7 @@ class Project:
                                 f"rules[{rule_index}].files.not[{fpath}]"
                             ),
                             "fixed": self.fix,
+                            "fixable": True,
                         },
                     )
         else:
@@ -193,6 +195,7 @@ class Project:
                             "file": fpath,
                             "definition": f"rules[{rule_index}].files.not[{f}]",
                             "fixed": self.fix,
+                            "fixable": True,
                         },
                     )
 

--- a/src/project_config/utils/jmespath.py
+++ b/src/project_config/utils/jmespath.py
@@ -812,6 +812,16 @@ def smart_fixer_by_expected_value(
     if ast["type"] == "field":
         key = ast["value"]
         return f"set(@, '{key}' `{json.dumps(expected_value)}`)"
+    elif ast["type"] == "subexpression":
+        temporal_object = {}
+
+        _obj = {}
+        for i, child in enumerate(reversed(ast["children"])):
+            if i == 0:
+                _obj = {child["value"]: expected_value}
+            else:
+                _obj = {child["value"]: _obj}
+        temporal_object = _obj
     elif ast["type"] == "function_expression" and ast["value"] == "type":
         if expected_value not in REVERSE_JMESPATH_TYPE_PYOBJECT:
             return ""


### PR DESCRIPTION
- Autofix constants in subexpressions.
- Show that file existence and absent errors are fixable.