### PR TITLE
Exclude coverage for classes inherited by `Protocol`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ exclude_lines = [
   "def __repr__\\(",
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
+  "class .*\\bProtocol\\):",
   "if __name__ == [\"']__main__[\"']:"
 ]
 omit = ["src/project_config/tests/*"]

--- a/src/project_config/serializers/__init__.py
+++ b/src/project_config/serializers/__init__.py
@@ -25,7 +25,7 @@ class SerializerFunction(Protocol):
         self,
         value: t.Any,
         **kwargs: t.Any,
-    ) -> SerializerResult:  # pragma: no cover
+    ) -> SerializerResult:
         ...
 
 


### PR DESCRIPTION
See https://github.com/mondeja/project-config-styles/pull/24