### PR TITLE
Add `flake8-encodings` plugin to flakeheaven linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
           - flake8-printf-formatting
           - flake8-pytest-style
           - flake8-bugbear
+          - flake8-encodings
           - dlint
           - pysetenv
         entry: pysetenv FLAKEHEAVEN_CACHE_TIMEOUT=0 flakeheaven lint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,7 +265,7 @@ Examples
 """  # noqa: E501
 
         examples_page_path = os.path.join(rootdir, "docs", "examples.rst")
-        with open(examples_page_path, "w") as f:
+        with open(examples_page_path, "w", encoding="utf-8") as f:
             f.write(examples_page_content)
 
     def _create_tutorials_pages():
@@ -311,7 +311,7 @@ Examples
                 "pages",
                 f"{tutorial_dirname}.rst",
             )
-            with open(tutorial_page_path, "w") as f:
+            with open(tutorial_page_path, "w", encoding="utf-8") as f:
                 f.write(tutorial_page_content)
 
     _create_examples_page()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ flake8-print = ["+*"]
 flake8-printf-formatting = ["+*"]
 flake8-pytest-style = ["+*"]
 flake8-bugbear = ["+*"]
+flake8-encodings = ["+*"]
 dlint = ["+*"]
 
 [tool.flakeheaven.exceptions."tests/**"]

--- a/src/project_config/config/__init__.py
+++ b/src/project_config/config/__init__.py
@@ -346,7 +346,7 @@ def initialize_config(config_filepath: str) -> str:
     os.makedirs(config_dirpath, exist_ok=True)
 
     if not os.path.isfile(config_filepath):
-        with open(config_filepath, "w") as f:
+        with open(config_filepath, "w", encoding="ascii") as f:
             f.write("")
 
     style_filepath = os.path.join(config_dirpath, "style.json5")
@@ -381,7 +381,7 @@ def initialize_config(config_filepath: str) -> str:
                 " 'cache', '5 minutes')))"
             )
 
-        with open(style_filepath, "w") as f:
+        with open(style_filepath, "w", encoding="ascii") as f:
             f.write(
                 '''{
   rules: [
@@ -429,14 +429,14 @@ def initialize_config(config_filepath: str) -> str:
         return f'{result}style = ["style.json5"]\ncache = "5 minutes"\n'
 
     def add_config_string_to_file(string: str) -> None:
-        with open(config_filepath, encoding="utf-8") as f:
+        with open(config_filepath, encoding="ascii") as f:
             config_lines = f.read().splitlines()
         if config_lines:
             add_separator = config_lines[-1] != ""
         else:
             add_separator = False
 
-        with open(config_filepath, "a") as f:
+        with open(config_filepath, "a", encoding="ascii") as f:
             if add_separator:
                 f.write("\n")
             f.write(string)
@@ -461,7 +461,7 @@ def initialize_config(config_filepath: str) -> str:
         return f"{config_filepath}[tool.project-config]"
 
     if os.path.isfile(config_filepath):
-        with open(config_filepath, encoding="utf-8") as f:
+        with open(config_filepath, encoding="ascii") as f:
             if f.read():
                 raise ProjectConfigAlreadyInitialized(config_filepath)
 

--- a/src/project_config/plugins/__init__.py
+++ b/src/project_config/plugins/__init__.py
@@ -190,7 +190,7 @@ class Plugins:
         if module_spec is not None:
             module_path = module_spec.origin
             if module_path is not None:
-                with open(module_path) as f:
+                with open(module_path, encoding="utf-8") as f:
                     for match in re.finditer(r"def ([^_]\w+)\(", f.read()):
                         yield match.group(1)
             # else:  # TODO: this could even happen? raise error

--- a/tests/test_acceptance/test_examples.py
+++ b/tests/test_acceptance/test_examples.py
@@ -12,7 +12,7 @@ from project_config.project import Project
 
 def _parse_example_metadata(example_dir):
     readme_rst_filepath = os.path.join(example_dir, "README.rst")
-    with open(readme_rst_filepath) as f:
+    with open(readme_rst_filepath, encoding="utf-8") as f:
         readme_lines = f.read().splitlines()
 
     metadata = {}


### PR DESCRIPTION
Fixes an edge case encoding bug on Windows.