### PR TITLE
Set `importlib-metadata-argparse-version` dependency version range

### DIFF
--- a/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
+++ b/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
@@ -32,4 +32,4 @@ linters:
     linter_repo: https://github.com/mondeja/project-config
     linter_rules_configuration_url: https://mondeja.github.io/project-config/latest/reference/styling.html
     linter_rules_url: https://mondeja.github.io/project-config/latest/reference/plugins.html
-    linter_version_cache: 0.9.4
+    linter_version_cache: 0.9.5

--- a/contrib/npm/package.json
+++ b/contrib/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "python-project-config",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Reproducible configuration across projects.",
   "author": {
     "name": "Álvaro Mondéjar Rubio",

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ Installation
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/project-config
-           rev: v0.9.4
+           rev: v0.9.5
            hooks:
              - id: project-config
 
@@ -50,7 +50,7 @@ Installation
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/project-config
-           rev: v0.9.4
+           rev: v0.9.5
            hooks:
              - id: project-config-fix
 
@@ -65,7 +65,7 @@ Installation
       .. code-block:: yaml
 
          PLUGINS:
-           - https://raw.githubusercontent.com/mondeja/project-config/v0.9.4/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
+           - https://raw.githubusercontent.com/mondeja/project-config/v0.9.5/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
          ENABLE_LINTERS:
            - PROJECT_CONFIG
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-config"
-version = "0.9.4"
+version = "0.9.5"
 description = "Reproducible configuration across projects."
 authors = [{ name = "Álvaro Mondéjar Rubio", email = "mondejar1994@gmail.com" }]
 license = "BSD-3-Clause"
@@ -29,7 +29,7 @@ keywords = [
   "meta-linter"
 ]
 dependencies = [
-  "importlib-metadata-argparse-version",
+  "importlib-metadata-argparse-version>=2,<3",
   "contextlib-chdir",
   "tomli-w~=1.0",
   'pyjson5',
@@ -135,12 +135,12 @@ serve = [
 cache = "30 days"
 style = [
   # Basic Python style: use Hatch, pre-commit, Github workflows, etc
-  "gh://mondeja/project-config-styles@v5.2/python/base.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/base.json5",
   # Documentation styles: use Sphinx with Readthedocs theme
-  "gh://mondeja/project-config-styles@v5.2/python/sphinx.json5",
-  "gh://mondeja/project-config-styles@v5.2/python/readthedocs.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/sphinx.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/readthedocs.json5",
   # Type checking with mypy
-  "gh://mondeja/project-config-styles@v5.2/python/mypy.json5",
+  "gh://mondeja/project-config-styles@v5.2.1/python/mypy.json5",
 ]
 
 [tool.bump]


### PR DESCRIPTION
This is breaking new installations because `importlib-metadata-argparse-version` v2 has been released.