### PR TITLE
Get rid of diskcache dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 package-lock.json
 .ruff_cache/
 .prettier-cache
+*.spec
 
 docs/dev/reference/
 docs/examples.rst

--- a/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
+++ b/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
@@ -32,4 +32,4 @@ linters:
     linter_repo: https://github.com/mondeja/project-config
     linter_rules_configuration_url: https://mondeja.github.io/project-config/latest/reference/styling.html
     linter_rules_url: https://mondeja.github.io/project-config/latest/reference/plugins.html
-    linter_version_cache: 0.9.6
+    linter_version_cache: 0.9.7

--- a/contrib/npm/package.json
+++ b/contrib/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "python-project-config",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Reproducible configuration across projects.",
   "author": {
     "name": "Álvaro Mondéjar Rubio",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ nitpick_ignore = [
     ("py:class", "project_config.types_.ErrorDict"),
     ("py:class", "pytest.MonkeyPatch"),
     ("py:class", "_pytest.monkeypatch.MonkeyPatch"),
+    ("py:class", "_blake2.blake2b"),
 ]
 nitpick_ignore_regex = [
     ("py:class", r"^t.[A-Z]\w+$"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,6 @@ autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "diskcache": ("https://grantjenks.com/docs/diskcache", None),
     "pyjson5": ("https://pyjson5.readthedocs.io/en/latest/", None),
     "deepmerge": ("https://deepmerge.readthedocs.io/en/latest/", None),
 }

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ Installation
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/project-config
-           rev: v0.9.6
+           rev: v0.9.7
            hooks:
              - id: project-config
 
@@ -50,7 +50,7 @@ Installation
       .. code-block:: yaml
 
          - repo: https://github.com/mondeja/project-config
-           rev: v0.9.6
+           rev: v0.9.7
            hooks:
              - id: project-config-fix
 
@@ -65,7 +65,7 @@ Installation
       .. code-block:: yaml
 
          PLUGINS:
-           - https://raw.githubusercontent.com/mondeja/project-config/v0.9.6/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
+           - https://raw.githubusercontent.com/mondeja/project-config/v0.9.7/contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml
          ENABLE_LINTERS:
            - PROJECT_CONFIG
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-config"
-version = "0.9.6"
+version = "0.9.7"
 description = "Reproducible configuration across projects."
 authors = [{ name = "Álvaro Mondéjar Rubio", email = "mondejar1994@gmail.com" }]
 license = "BSD-3-Clause"
@@ -145,6 +145,7 @@ style = [
 [tool.bump]
 targets = [
   { file = "pyproject.toml", regex = "(version = [\"'])(\\d+\\.\\d+\\.\\d+)([\"'])" },
+  { file = "src/project_config/__init__.py", regex = "(__version__ = [\"'])(\\d+\\.\\d+\\.\\d+)([\"'])" },
   { file = "docs/install.rst", regex = "(v)(\\d+\\.\\d+\\.\\d+)" },
   { file = "contrib/mega-linter-plugin-project-config/project-config.megalinter-descriptor.yml" },
   { file = "contrib/npm/package.json", regex = '(version": ")(\d+\.\d+\.\d+)' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
   "identify~=2.0",
   "ruamel.yaml~=0.17",
   "appdirs~=1.0",
-  "diskcache~=5.0",
   "requests",
   "requests-futures~=1.0",
   "deepmerge~=1.0",

--- a/src/project_config/__init__.py
+++ b/src/project_config/__init__.py
@@ -9,7 +9,7 @@ from project_config.constants import Error, InterruptingError, ResultValue
 from project_config.types_ import ActionsContext
 
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 
 
 __all__ = [

--- a/src/project_config/cache.py
+++ b/src/project_config/cache.py
@@ -71,7 +71,7 @@ def write_file(fpath: str, value: Any) -> None:  # noqa: D102
 
 
 class Cache:
-    """Global cache to avoid recomputation of expensive intermediate objects."""
+    """Global cache to avoid recomputing expensive intermediate objects."""
 
     _expiration_time: float | int | None = 30
 

--- a/src/project_config/cache.py
+++ b/src/project_config/cache.py
@@ -2,42 +2,20 @@
 
 from __future__ import annotations
 
-import importlib.util
+import base64
+import hashlib
 import os
 import pickle
 import re
 import shutil
 import sys
+import time
 from typing import Any, Iterator
 
 import appdirs
 
 from project_config.compat import importlib_metadata
 
-
-# ---
-
-# Workaround for https://github.com/grantjenks/python-diskcache/pull/269
-# TODO: Remove this workaround once the PR is merged and released.
-
-_diskcache_init_path = importlib.util.find_spec(
-    "diskcache",
-).origin  # type: ignore
-_diskcache_core_spec = importlib.util.spec_from_file_location(
-    "diskcache.core",
-    os.path.join(
-        os.path.dirname(_diskcache_init_path),  # type: ignore
-        "core.py",
-    ),
-)
-_diskcache_core = importlib.util.module_from_spec(
-    _diskcache_core_spec,  # type: ignore
-)
-_diskcache_core_spec.loader.exec_module(_diskcache_core)  # type: ignore
-
-DiskCache = _diskcache_core.Cache
-
-# ---
 
 CACHE_DIR = appdirs.user_data_dir(
     appname=(
@@ -70,13 +48,31 @@ def generate_possible_cache_dirs() -> Iterator[str]:
         )
 
 
-class Cache:
-    """Wrapper for a unique :py:class:`diskcache.core.Cache` instance."""
+def get_creation_time_from_fpath(fpath: str) -> int:
+    """Get creation time of an entry in the cache given its path."""
+    with open(fpath, "rb") as file:
+        return int(file.readline())
 
-    _cache = DiskCache(
-        directory=CACHE_DIR,
-        disk_pickle_protocol=pickle.HIGHEST_PROTOCOL,
-    )
+
+def read_file(fpath: str) -> bytes:  # noqa: D102
+    """Read a file from the cache."""
+    with open(fpath, "rb") as f:
+        fcontent = f.read()
+        _, content = fcontent.split(b"\n", 1)
+        return content
+
+
+def write_file(fpath: str, value: Any) -> None:  # noqa: D102
+    """Write a file to the cache."""
+    with open(fpath, "wb") as f:
+        f.write(str(int(time.time())).encode())
+        f.write(b"\n")
+        f.write(pickle.dumps(value))
+
+
+class Cache:
+    """Global cache to avoid recomputation of expensive intermediate objects."""
+
     _expiration_time: float | int | None = 30
 
     def __init__(self) -> None:  # noqa: D107 pragma: no cover
@@ -90,27 +86,50 @@ class Cache:
                 shutil.rmtree(possible_cache_dirpath)
 
     @classmethod
-    def set(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: A003, D102
-        return cls._cache.set(
-            *args,
-            **dict(
-                expire=cls._expiration_time,
-                **kwargs,
-            ),
-        )
+    def generate_unique_key_from_tree_entry(cls, tree_entry: str) -> str:
+        """Generate a unique key."""
+        return base64.urlsafe_b64encode(
+            hashlib.md5(tree_entry.encode()).digest(),
+        ).decode("utf-8")
 
     @classmethod
-    def get(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
-        return cls._cache.get(*args, **kwargs)  # pragma: no cover
+    def get(cls, tree_entry: str) -> Any:  # noqa: D102
+        key = cls.generate_unique_key_from_tree_entry(tree_entry)
+        fpath = os.path.join(CACHE_DIR, key)
+        if os.path.isfile(fpath):
+            creation_time = get_creation_time_from_fpath(fpath)
+            if time.time() < creation_time + (cls._expiration_time or 0):
+                return pickle.loads(read_file(fpath))
+            os.remove(fpath)
+        return None
+
+    @classmethod
+    def set(cls, tree_entry: str, value: Any) -> None:  # noqa: D102
+        key = cls.generate_unique_key_from_tree_entry(tree_entry)
+        fpath = os.path.join(CACHE_DIR, key)
+        if not os.path.isfile(fpath):
+            write_file(fpath, value)
+        elif time.time() > get_creation_time_from_fpath(fpath) + (
+            cls._expiration_time or 0
+        ):
+            os.remove(fpath)
+            write_file(fpath, value)
+
+    @classmethod
+    def ensure_dir(cls) -> None:
+        """Ensure the cache directory exists."""
+        if not os.path.isdir(CACHE_DIR):
+            os.makedirs(CACHE_DIR)
 
     @classmethod
     def set_expiration_time(
         cls,
         expiration_time: float | int | None = None,
     ) -> None:
-        """Set the expiration time for the cache.
+        """Configure global cache.
 
         Args:
-            expiration_time (float): Time in seconds.
+            expiration_time (float): Expiration time in seconds for cached
+                objects.
         """
         cls._expiration_time = expiration_time

--- a/src/project_config/config/__init__.py
+++ b/src/project_config/config/__init__.py
@@ -293,6 +293,8 @@ class FileConfig:
             store_raw_config (bool): If ``True``, the raw configuration
                 of the file will be stored in the ``raw_`` attribute.
         """
+        Cache.ensure_dir()
+
         self.path, config = read_config(rootdir, path)
 
         if store_raw_config:

--- a/src/project_config/tree.py
+++ b/src/project_config/tree.py
@@ -125,6 +125,7 @@ def cache_file(  # noqa: PLR0912, PLR0915
             # the file is a directory, skip caching
             return
 
+        # use hashes for files with multiple serializers
         fhash = hash_file(fname)
 
         previous_value_in_cache = Cache.get(fhash)
@@ -143,10 +144,7 @@ def cache_file(  # noqa: PLR0912, PLR0915
                         prefer_serializer=serializer,
                     )
 
-            Cache.set(
-                fhash,
-                new_cache_value,
-            )
+            Cache.set(fhash, new_cache_value)
         else:
             # file is already cached, just update serialized versions
             _changed = False
@@ -161,10 +159,7 @@ def cache_file(  # noqa: PLR0912, PLR0915
                         _changed = True
 
             if _changed:
-                Cache.set(
-                    fhash,
-                    previous_value_in_cache,
-                )
+                Cache.set(fhash, previous_value_in_cache)
     else:
         # the file is remote, check if resides in the cache
         previous_value_in_cache = Cache.get(fname)
@@ -253,10 +248,7 @@ def cached_local_file(
             result = previous_value_in_cache.pop("py")
         else:
             result = previous_value_in_cache[serializer]
-        Cache.set(
-            fhash,
-            previous_value_in_cache,
-        )
+        Cache.set(fhash, previous_value_in_cache)
     else:
         result = previous_value_in_cache[serializer]
     return result

--- a/src/project_config/utils/crypto.py
+++ b/src/project_config/utils/crypto.py
@@ -5,21 +5,22 @@ from __future__ import annotations
 import hashlib
 
 
-def hash_digest(data: bytes) -> bytes:
-    """Return the hash digest of the data.
+def _build_hash(data: bytes) -> hashlib.blake2b:
+    return hashlib.blake2b(data, digest_size=32)
+
+
+def hash_hexdigest(data: bytes) -> str:
+    """Return the hexadecimal hash digest of the data.
 
     :param data: The data to hash.
     :type data: bytes
-    :return: The hash digest of the data.
-    :rtype: bytes
+    :return: The hexadecimal hash digest of the data.
+    :rtype: str
     """
-    return hashlib.blake2b(
-        data,
-        digest_size=32,
-    ).digest()
+    return _build_hash(data).hexdigest()
 
 
-def hash_file(filename: str) -> bytes:
+def hash_file(filename: str) -> str:
     """Return the hash digest of the file.
 
     :param filename: The file to hash.
@@ -28,4 +29,4 @@ def hash_file(filename: str) -> bytes:
     :rtype: str
     """
     with open(filename, "rb") as f:
-        return hash_digest(f.read())
+        return hash_hexdigest(f.read())


### PR DESCRIPTION
This would allow to distribute autocontained binaries using PyInstaller. Currently the lazy import of diskcache is difficulting that. Additionally, the library is slower than a basic implementation like this.